### PR TITLE
Allow multi-instances of annoy trees to be loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Java JNI wrapper around [annoy (C++)](https://github.com/spotify/annoy).
 <dependency>
     <groupId>com.spotify</groupId>
     <artifactId>annoy-java</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
 </dependency>
 ```
 At the moment, the jar is only published on Spotify's internal Artifactory.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>annoy-java</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/src/main/java/com/spotify/annoy/jni/base/AnnoyIndex.java
+++ b/src/main/java/com/spotify/annoy/jni/base/AnnoyIndex.java
@@ -20,14 +20,13 @@
 
 package com.spotify.annoy.jni.base;
 
-import java.io.Closeable;
 import java.util.List;
 
 /**
  * Annoy interface
  * Modeled after: https://github.com/spotify/annoy/blob/master/annoy/__init__.py, sorta
  */
-public interface AnnoyIndex extends Closeable {
+public interface AnnoyIndex extends AutoCloseable {
 
   List<Integer> getNearestByVector(List<Float> vector, int nbNeighbors);
 

--- a/src/main/java/com/spotify/annoy/jni/base/AnnoyIndex.java
+++ b/src/main/java/com/spotify/annoy/jni/base/AnnoyIndex.java
@@ -20,13 +20,14 @@
 
 package com.spotify.annoy.jni.base;
 
+import java.io.Closeable;
 import java.util.List;
 
 /**
  * Annoy interface
  * Modeled after: https://github.com/spotify/annoy/blob/master/annoy/__init__.py, sorta
  */
-public interface AnnoyIndex {
+public interface AnnoyIndex extends Closeable {
 
   List<Integer> getNearestByVector(List<Float> vector, int nbNeighbors);
 
@@ -41,6 +42,8 @@ public interface AnnoyIndex {
   float getDistance(int itemA, int itemB);
 
   int size();
+
+  void close();
 
   AnnoyIndex save(String filename);
 }

--- a/src/main/java/com/spotify/annoy/jni/base/AnnoyIndexImpl.java
+++ b/src/main/java/com/spotify/annoy/jni/base/AnnoyIndexImpl.java
@@ -138,7 +138,7 @@ class AnnoyIndexImpl implements AnnoyIndex {
   // Native cpp  methods
 
   // returns the c++ memory index for the object
-  private native int cppCtor(int dim, int metric);
+  private native long cppCtor(int dim, int metric);
 
   private native void cppDtor(long cppPtr);
 

--- a/src/main/java/com/spotify/annoy/jni/base/AnnoyIndexImpl.java
+++ b/src/main/java/com/spotify/annoy/jni/base/AnnoyIndexImpl.java
@@ -37,42 +37,42 @@ class AnnoyIndexImpl implements AnnoyIndex {
   public List<Integer> getNearestByVector(List<Float> vector, int nbNeighbors) {
     validateVecSize(vector);
     return primitiveToBoxed(
-        cppGetNearestByVector(this.cppPtr, boxedToPrimitive(vector), nbNeighbors));
+        cppGetNearestByVector(cppPtr, boxedToPrimitive(vector), nbNeighbors));
   }
 
   public List<Integer> getNearestByVector(List<Float> vector, int nbNeighbors, int searchK) {
     validateVecSize(vector);
     return primitiveToBoxed(
-        cppGetNearestByVectorK(this.cppPtr, boxedToPrimitive(vector), nbNeighbors, searchK));
+        cppGetNearestByVectorK(cppPtr, boxedToPrimitive(vector), nbNeighbors, searchK));
   }
 
   public List<Integer> getNearestByItem(int item, int nbNeighbors) {
-    return primitiveToBoxed(cppGetNearestByItem(this.cppPtr, item, nbNeighbors));
+    return primitiveToBoxed(cppGetNearestByItem(cppPtr, item, nbNeighbors));
   }
 
   public List<Integer> getNearestByItem(int item, int nbNeighbors, int searchK) {
-    return primitiveToBoxed(cppGetNearestByItemK(this.cppPtr, item, nbNeighbors, searchK));
+    return primitiveToBoxed(cppGetNearestByItemK(cppPtr, item, nbNeighbors, searchK));
   }
 
   public AnnoyIndex save(String filename) {
-    cppSave(this.cppPtr, filename);
+    cppSave(cppPtr, filename);
     return this;
   }
 
   public void close() {
-    cppDtor(this.cppPtr);
+    cppDtor(cppPtr);
   }
 
   public List<Float> getItemVector(int item) {
-    return primitiveToBoxed(cppGetItemVector(this.cppPtr, item));
+    return primitiveToBoxed(cppGetItemVector(cppPtr, item));
   }
 
   public float getDistance(int itemA, int itemB) {
-    return cppGetDistance(this.cppPtr, itemA, itemB);
+    return cppGetDistance(cppPtr, itemA, itemB);
   }
 
   public int size() {
-    return cppSize(this.cppPtr);
+    return cppSize(cppPtr);
   }
 
   // Construction
@@ -85,7 +85,7 @@ class AnnoyIndexImpl implements AnnoyIndex {
 
   AnnoyIndexImpl addItem(int item, List<Float> vector) {
     validateVecSize(vector);
-    cppAddItem(this.cppPtr, item, boxedToPrimitive(vector));
+    cppAddItem(cppPtr, item, boxedToPrimitive(vector));
     return this;
   }
 
@@ -98,7 +98,7 @@ class AnnoyIndexImpl implements AnnoyIndex {
   }
 
   AnnoyIndexImpl build(int nbTrees) {
-    cppBuild(this.cppPtr, nbTrees);
+    cppBuild(cppPtr, nbTrees);
     return this;
   }
 
@@ -106,12 +106,12 @@ class AnnoyIndexImpl implements AnnoyIndex {
     if (Files.notExists(Paths.get(filename))) {
       throw new FileNotFoundException("Cannot find annoy index: " + filename);
     }
-    cppLoad(this.cppPtr, filename);
+    cppLoad(cppPtr, filename);
     return this;
   }
 
   AnnoyIndexImpl setSeed(int seed) {
-    cppSetSeed(this.cppPtr, seed);
+    cppSetSeed(cppPtr, seed);
     return this;
   }
 

--- a/src/main/resources/jni/Makefile
+++ b/src/main/resources/jni/Makefile
@@ -26,6 +26,8 @@ HEADER    :=com_spotify_annoy_jni_base_AnnoyIndexImpl.h
 all: annoy
 
 annoy:
-#	javah -cp .. -o ./$(HEADER) -jni com.spotify.annoy.jni.base.AnnoyIndexImpl
+	javah -cp ../../java -o ./$(HEADER) -jni com.spotify.annoy.jni.base.AnnoyIndexImpl
+	curl -sSO https://raw.githubusercontent.com/spotify/annoy/master/src/annoylib.h
+	curl -sSO https://raw.githubusercontent.com/spotify/annoy/master/src/kissrandom.h
 	$(CC) $(CFLAGS) $(JNIFLAGS) $(FASTFLAGS) -o $(SOBJ) $(SOURCE)
 

--- a/src/main/resources/jni/Makefile
+++ b/src/main/resources/jni/Makefile
@@ -26,6 +26,6 @@ HEADER    :=com_spotify_annoy_jni_base_AnnoyIndexImpl.h
 all: annoy
 
 annoy:
-	javah -cp .. -o ./$(HEADER) -jni com.spotify.annoy.jni.base.AnnoyIndexImpl
+#	javah -cp .. -o ./$(HEADER) -jni com.spotify.annoy.jni.base.AnnoyIndexImpl
 	$(CC) $(CFLAGS) $(JNIFLAGS) $(FASTFLAGS) -o $(SOBJ) $(SOURCE)
 

--- a/src/main/resources/jni/Makefile
+++ b/src/main/resources/jni/Makefile
@@ -26,8 +26,6 @@ HEADER    :=com_spotify_annoy_jni_base_AnnoyIndexImpl.h
 all: annoy
 
 annoy:
-	javah -cp ../../java -o ./$(HEADER) -jni com.spotify.annoy.jni.base.AnnoyIndexImpl
-	curl -sSO https://raw.githubusercontent.com/spotify/annoy/master/src/annoylib.h
-	curl -sSO https://raw.githubusercontent.com/spotify/annoy/master/src/kissrandom.h
+	javah -cp .. -o ./$(HEADER) -jni com.spotify.annoy.jni.base.AnnoyIndexImpl
 	$(CC) $(CFLAGS) $(JNIFLAGS) $(FASTFLAGS) -o $(SOBJ) $(SOURCE)
 

--- a/src/main/resources/jni/com_spotify_annoy_jni_base_AnnoyIndexImpl.cpp
+++ b/src/main/resources/jni/com_spotify_annoy_jni_base_AnnoyIndexImpl.cpp
@@ -35,177 +35,128 @@ namespace
     };
 }
 
-
-/*
- * Class:     com_spotify_annoy_jni_base_AnnoyIndexImpl
- * Method:    cppCtor
- * Signature: (I)V
- */
     JNIEXPORT jint JNICALL Java_com_spotify_annoy_jni_base_AnnoyIndexImpl_cppCtor
-(JNIEnv *env, jobject obj, jint jni_int, jint metric)
+(JNIEnv *env, jobject obj, jlong cpp_ptr, jint jni_int, jint metric)
 {
-    return new ANN(jni_int, metric);
+    return (intptr_t) new ANN(jni_int, metric);
 }
 
-/*
- * Class:     com_spotify_annoy_jni_base_AnnoyIndexImpl
- * Method:    cppSetSeed
- * Signature: (I)V
- */
     JNIEXPORT void JNICALL Java_com_spotify_annoy_jni_base_AnnoyIndexImpl_cppSetSeed
-(JNIEnv *env, jobject obj, jint seed)
+(JNIEnv *env, jobject obj,  jlong cpp_ptr, jint seed)
 {
-    annoy_index->set_seed(seed);
+    ANN *ann = (ANN*) cpp_ptr;
+    ann->annoy_index->set_seed(seed);
 }
 
-/*
- * Class:     com_spotify_annoy_jni_base_AnnoyIndexImpl
- * Method:    cppAddItem
- * Signature: (I[F)V
- */
     JNIEXPORT void JNICALL Java_com_spotify_annoy_jni_base_AnnoyIndexImpl_cppAddItem
-(JNIEnv *env, jobject obj, jint item, jfloatArray jni_floats)
+(JNIEnv *env, jobject obj, jlong cpp_ptr, jint item, jfloatArray jni_floats)
 {
     jfloat *inCArray = env->GetFloatArrayElements(jni_floats, NULL);
     if (NULL == inCArray) return;
-    annoy_index->add_item(item, inCArray);
+    ANN *ann = (ANN*) cpp_ptr;
+    ann->annoy_index->add_item(item, inCArray);
 }
 
-/*
- * Class:     com_spotify_annoy_jni_base_AnnoyIndexImpl
- * Method:    cppGetNearestByVector
- * Signature: ([FI)[I
- */
     JNIEXPORT jintArray JNICALL Java_com_spotify_annoy_jni_base_AnnoyIndexImpl_cppGetNearestByVector
-(JNIEnv *env, jobject obj, jfloatArray arr, jint n)
+(JNIEnv *env, jobject obj, jlong cpp_ptr, jfloatArray arr, jint n)
 {
     jfloat *inCArray = env->GetFloatArrayElements(arr, NULL);
     if (NULL == inCArray) return NULL;
     size_t search_k = (size_t)-1;
     vector<jint> result;
-    annoy_index->get_nns_by_vector(inCArray, n, search_k, &result, NULL);
+    ANN *ann = (ANN*) cpp_ptr;
+    ann->annoy_index->get_nns_by_vector(inCArray, n, search_k, &result, NULL);
     return vec_to_jintArray(env, result);
 }
 
-/*
- * Class:     com_spotify_annoy_jni_base_AnnoyIndexImpl
- * Method:    cppGetNearestByVectorK
- * Signature: ([FII)[I
- */
     JNIEXPORT jintArray JNICALL Java_com_spotify_annoy_jni_base_AnnoyIndexImpl_cppGetNearestByVectorK
-(JNIEnv *env, jobject obj, jfloatArray arr, jint n, jint search_k)
+(JNIEnv *env, jobject obj, jlong cpp_ptr, jfloatArray arr, jint n, jint search_k)
 {
     jfloat *inCArray = env->GetFloatArrayElements(arr, NULL);
     if (NULL == inCArray) return NULL;
     vector<jint> result;
-    annoy_index->get_nns_by_vector(inCArray, n, search_k, &result, NULL);
+    ANN *ann = (ANN*) cpp_ptr;
+    ann->annoy_index->get_nns_by_vector(inCArray, n, search_k, &result, NULL);
     return vec_to_jintArray(env, result);
 }
 
 
-/*
- * Class:     com_spotify_annoy_jni_base_AnnoyIndexImpl
- * Method:    cppGetNearestByItem
- * Signature: ([FI)[I
- */
     JNIEXPORT jintArray JNICALL Java_com_spotify_annoy_jni_base_AnnoyIndexImpl_cppGetNearestByItem
-(JNIEnv *env, jobject obj, jint item, jint n)
+(JNIEnv *env, jobject obj, jlong cpp_ptr, jint item, jint n)
 {
     size_t search_k = (size_t)-1;
     vector<jint> result;
-    annoy_index->get_nns_by_item(item, n, search_k, &result, NULL);
+    ANN *ann = (ANN*) cpp_ptr;
+    ann->annoy_index->get_nns_by_item(item, n, search_k, &result, NULL);
     return vec_to_jintArray(env, result);
 }
 
-/*
- * Class:     com_spotify_annoy_jni_base_AnnoyIndexImpl
- * Method:    cppGetNearestByItemK
- * Signature: ([FII)[I
- */
     JNIEXPORT jintArray JNICALL Java_com_spotify_annoy_jni_base_AnnoyIndexImpl_cppGetNearestByItemK
-(JNIEnv *env, jobject obj, jint item, jint n, jint search_k)
+(JNIEnv *env, jobject obj, jlong cpp_ptr, jint item, jint n, jint search_k)
 {
     vector<jint> result;
-    annoy_index->get_nns_by_item(item, n, search_k, &result, NULL);
+    ANN *ann = (ANN*) cpp_ptr;
+    ann->annoy_index->get_nns_by_item(item, n, search_k, &result, NULL);
     return vec_to_jintArray(env, result);
 }
 
-/*
- * Class:     com_spotify_annoy_jni_base_AnnoyIndexImpl
- * Method:    cppBuild
- * Signature: (I)V
- */
     JNIEXPORT void JNICALL Java_com_spotify_annoy_jni_base_AnnoyIndexImpl_cppBuild
-(JNIEnv *env, jobject obj, jint jni_int)
+(JNIEnv *env, jobject obj, jlong cpp_ptr, jint jni_int)
 {
-    return annoy_index->build(jni_int);
+    ANN *ann = (ANN*) cpp_ptr;
+    ann->annoy_index->build(jni_int);
 }
 
-/*
- * Class:     com_spotify_annoy_jni_base_AnnoyIndexImpl
- * Method:    cppSave
- * Signature: (Ljava/lang/String;)V
- */
     JNIEXPORT void JNICALL Java_com_spotify_annoy_jni_base_AnnoyIndexImpl_cppSave
-(JNIEnv *env, jobject obj, jstring jni_filename)
+(JNIEnv *env, jobject obj, jlong cpp_ptr, jstring jni_filename)
 {
     const char *filename= env->GetStringUTFChars(jni_filename, NULL);
     if (NULL == filename) return;
-    bool b = annoy_index->save(filename);
+    ANN *ann = (ANN*) cpp_ptr;
+    bool b = ann->annoy_index->save(filename);
     env->ReleaseStringUTFChars(jni_filename, filename);  // release resources
-    return;
 }
 
-/*
- * Class:     com_spotify_annoy_jni_base_AnnoyIndexImpl
- * Method:    cppLoad
- * Signature: (Ljava/lang/String;)V
- */
     JNIEXPORT void JNICALL Java_com_spotify_annoy_jni_base_AnnoyIndexImpl_cppLoad
-(JNIEnv *env, jobject obj, jstring jni_filename)
+(JNIEnv *env, jobject obj, jlong cpp_ptr, jstring jni_filename)
 {
     const char *filename= env->GetStringUTFChars(jni_filename, NULL);
     if (NULL == filename) return;
-    bool b = annoy_index->load(filename);
+    ANN *ann = (ANN*) cpp_ptr;
+    bool b = ann->annoy_index->load(filename);
     env->ReleaseStringUTFChars(jni_filename, filename);  // release resources
-    return;
 }
 
-/*
- * Class:     com_spotify_annoy_jni_base_AnnoyIndexImpl
- * Method:    cppGetItemVector
- * Signature: (I)[F
- */
     JNIEXPORT jfloatArray JNICALL Java_com_spotify_annoy_jni_base_AnnoyIndexImpl_cppGetItemVector
-(JNIEnv *env, jobject obj, jint i)
+(JNIEnv *env, jobject obj, jlong cpp_ptr, jint i)
 {
-    vector<jfloat> vec(f);
-    annoy_index->get_item(i, &vec[0]);
+    ANN *ann = (ANN*) cpp_ptr;
+    vector<jfloat> vec(ann->f);
+    ann->annoy_index->get_item(i, &vec[0]);
     jfloatArray outJNIArray = env->NewFloatArray(vec.size());
     if (NULL == outJNIArray) return NULL;
     env->SetFloatArrayRegion(outJNIArray, 0 , vec.size(), &vec[0]);  // copy
     return outJNIArray;
 }
 
-/*
- * Class:     com_spotify_annoy_jni_base_AnnoyIndexImpl
- * Method:    cppGetDistance
- * Signature: (II)F
- */
     JNIEXPORT jfloat JNICALL Java_com_spotify_annoy_jni_base_AnnoyIndexImpl_cppGetDistance
-(JNIEnv *env, jobject obj, jint jni_i, jint jni_j)
+(JNIEnv *env, jobject obj, jlong cpp_ptr, jint jni_i, jint jni_j)
 {
-    return (jfloat) annoy_index->get_distance(jni_i, jni_j);
+    ANN *ann = (ANN*) cpp_ptr;
+    return (jfloat) ann->annoy_index->get_distance(jni_i, jni_j);
 }
 
-/*
- * Class:     com_spotify_annoy_jni_base_AnnoyIndexImpl
- * Method:    cppSize
- * Signature: ()I
- */
+
     JNIEXPORT jint JNICALL Java_com_spotify_annoy_jni_base_AnnoyIndexImpl_cppSize
-(JNIEnv *env, jobject obj)
+(JNIEnv *env, jlong cpp_ptr, jobject obj)
 {
-    return (jint) annoy_index->get_n_items();
+    ANN *ann = (ANN*) cpp_ptr;
+    return (jint) ann->annoy_index->get_n_items();
 }
 
+JNIEXPORT void JNICALL Java_com_spotify_annoy_jni_base_AnnoyIndexImpl_cppDtor
+  (JNIEnv *env, jobject obj, jlong cpp_ptr)
+{
+    ANN *ann = (ANN*) cpp_ptr;
+    delete ann;
+}

--- a/src/main/resources/jni/com_spotify_annoy_jni_base_AnnoyIndexImpl.cpp
+++ b/src/main/resources/jni/com_spotify_annoy_jni_base_AnnoyIndexImpl.cpp
@@ -35,14 +35,14 @@ namespace
     };
 }
 
-    JNIEXPORT jint JNICALL Java_com_spotify_annoy_jni_base_AnnoyIndexImpl_cppCtor
-(JNIEnv *env, jobject obj, jlong cpp_ptr, jint jni_int, jint metric)
+    JNIEXPORT jlong JNICALL Java_com_spotify_annoy_jni_base_AnnoyIndexImpl_cppCtor
+(JNIEnv *env, jobject obj, jint jni_int, jint metric)
 {
     return (intptr_t) new ANN(jni_int, metric);
 }
 
     JNIEXPORT void JNICALL Java_com_spotify_annoy_jni_base_AnnoyIndexImpl_cppSetSeed
-(JNIEnv *env, jobject obj,  jlong cpp_ptr, jint seed)
+(JNIEnv *env, jobject obj, jlong cpp_ptr, jint seed)
 {
     ANN *ann = (ANN*) cpp_ptr;
     ann->annoy_index->set_seed(seed);
@@ -148,7 +148,7 @@ namespace
 
 
     JNIEXPORT jint JNICALL Java_com_spotify_annoy_jni_base_AnnoyIndexImpl_cppSize
-(JNIEnv *env, jlong cpp_ptr, jobject obj)
+(JNIEnv *env, jobject obj, jlong cpp_ptr)
 {
     ANN *ann = (ANN*) cpp_ptr;
     return (jint) ann->annoy_index->get_n_items();

--- a/src/test/java/com/spotify/annoy/jni/base/AnnoyTest.java
+++ b/src/test/java/com/spotify/annoy/jni/base/AnnoyTest.java
@@ -94,7 +94,6 @@ public class AnnoyTest {
     assertEquals(annoyIndex.getDistance(0, 1), expectedEuclideanDistance, EPS);
   }
 
-
   @Test
   public void setSeedTest() {
     Annoy.newIndex(3)

--- a/src/test/java/com/spotify/annoy/jni/base/AnnoyTest.java
+++ b/src/test/java/com/spotify/annoy/jni/base/AnnoyTest.java
@@ -43,6 +43,7 @@ public class AnnoyTest {
   private static final List<Float> v1 = Arrays.asList(3f, 4f, 5f);
   private static final List<Float> v2 = Arrays.asList(6f, 7f, 8f);
   private static final List<List<Float>> allVecs = Arrays.asList(v0, v1, v2);
+  private static final List<List<Float>> twoVecs = Arrays.asList(v1, v2);
   private static final float EPS = 0.00001f;
 
   @Test
@@ -54,6 +55,24 @@ public class AnnoyTest {
     assertThat(annoyIndex.size(), is(3));
     assertThat(annoyIndex.getItemVector(1), equalTo(v1));
     assertThat(annoyIndex.getItemVector(0), not(v1));
+  }
+
+  @Test
+  public void multiTreeTest() {
+    AnnoyIndex annoyIndex1 = Annoy.newIndex(3)
+        .addAllItems(allVecs)
+        .build(2);
+    AnnoyIndex annoyIndex2 = Annoy.newIndex(3)
+        .addAllItems(twoVecs)
+        .build(2);
+
+    assertThat(annoyIndex1.size(), is(3));
+    assertThat(annoyIndex1.getItemVector(2), equalTo(v2));
+    assertThat(annoyIndex1.getItemVector(0), not(v1));
+
+    assertThat(annoyIndex2.size(), is(2));
+    assertThat(annoyIndex2.getItemVector(1), equalTo(v2));
+    assertThat(annoyIndex2.getItemVector(0), not(v2));
   }
 
   @Test


### PR DESCRIPTION
We are passing the pointer for the tree so it can be shared between cpp and java. Now, the trees have to be explicitly closed so there is no build up of memory on the cpp side. 

Next steps:
 - update readme to let users know to always close the tree. 
 - make sure this version works for current users